### PR TITLE
Change logging to a more library-like model

### DIFF
--- a/gpcam/__init__.py
+++ b/gpcam/__init__.py
@@ -1,3 +1,8 @@
 from . import _version
+from loguru import logger
+import sys
 
 __version__ = _version.get_versions()['version']
+
+logger.remove()
+logger.add(sys.stderr, level='ERROR')

--- a/gpcam/__init__.py
+++ b/gpcam/__init__.py
@@ -4,5 +4,4 @@ import sys
 
 __version__ = _version.get_versions()['version']
 
-logger.remove()
-logger.add(sys.stderr, level='ERROR')
+logger.disable('gpcam')

--- a/gpcam/autonomous_experimenter.py
+++ b/gpcam/autonomous_experimenter.py
@@ -130,7 +130,13 @@ class AutonomousExperimenterGP():
                  training_dask_client=None,
                  acq_func_opt_dask_client=None,
                  ram_economy=True,
+                 info=False
                  ):
+        if info:
+            logger.enable('gpcam')
+            logger.enable('fvgp')
+            logger.enable('hgdl')
+
         dim = len(parameter_bounds)
         self.instrument_func = instrument_func
         self.hyperparameter_bounds = hyperparameter_bounds

--- a/gpcam/gp_optimizer.py
+++ b/gpcam/gp_optimizer.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import numpy as np
+from loguru import logger
+
 from fvgp.fvgp import fvGP
 from fvgp.gp import GP
 from gpcam import surrogate_model as sm
@@ -107,10 +109,9 @@ class GPOptimizer(GP):
             return sm.evaluate_acquisition_function(
                 x, self, acquisition_function, origin, cost_function,
                 self.cost_function_parameters)
-        except Exception as a:
-            print("Evaluating the acquisition function was not successful.")
-            print("Error Message:")
-            print(str(a))
+        except Exception as ex:
+            logger.error(ex)
+            logger.error("Evaluating the acquisition function was not successful.")
 
     def tell(self, x, y, variances=None):
         """
@@ -324,8 +325,8 @@ class GPOptimizer(GP):
         """
         try:
             self.kill_training(opt_obj)
-        except Exception as e:
-            print("kill not sucessful in GPOptimizer due to: ", str(e))
+        except Exception as ex:
+            raise RuntimeError("kill not sucessful in GPOptimizer") from ex
 
     ##############################################################
     def update_hyperparameters(self, opt_obj):
@@ -409,10 +410,10 @@ class GPOptimizer(GP):
             that, only in case of `method` = `hgdl` can be queried for solutions.
         """
 
-        print("ask() initiated with hyperparameters:", self.hyperparameters)
-        #print("optimization method: ", method)
-        #print("bounds: ", bounds)
-        #print("acq func: ", acquisition_function)
+        logger.debug("ask() initiated with hyperparameters: {}", self.hyperparameters)
+        logger.debug("optimization method: {}", method)
+        logger.debug("bounds:\n{}", bounds)
+        logger.debug("acq func: {}", acquisition_function)
         if bounds is None: bounds = self.input_space_bounds
         maxima, func_evals, opt_obj = sm.find_acquisition_function_maxima(
             self,
@@ -656,7 +657,7 @@ class fvGPOptimizer(fvGP, GPOptimizer):
             )
             self.gp_initialized = True
         else:
-            print("No initialization. fvGP already initialized")
+            raise RuntimeError("No initialization. fvGP already initialized")
 
     ##############################################################
     def update_fvgp(self):

--- a/gpcam/surrogate_model.py
+++ b/gpcam/surrogate_model.py
@@ -3,6 +3,8 @@ import itertools
 from functools import partial
 
 import numpy as np
+from loguru import logger
+
 from hgdl.hgdl import HGDL
 from scipy.optimize import differential_evolution as devo, minimize
 
@@ -95,15 +97,15 @@ def find_acquisition_function_maxima(gp, acquisition_function,
                                      dask_client=False):
     bounds = np.array(optimization_bounds)
     opt_obj = None
-    #print("====================================")
-    print("Finding acquisition function maxima via ",optimization_method," method")
-    #print("tolerance: ", optimization_tol)
-    #print("population size: ", optimization_pop_size)
-    #print("maximum number of iterations: ", optimization_max_iter)
-    #print("bounds: ")
-    #print(bounds)
-    #print("cost function parameters: ", cost_function_parameters)
-    #print("====================================")
+    logger.debug("====================================")
+    logger.debug(f"Finding acquisition function maxima via {optimization_method} method")
+    logger.debug("tolerance: {}", optimization_tol)
+    logger.debug("population size: {}", optimization_pop_size)
+    logger.debug("maximum number of iterations: {}", optimization_max_iter)
+    logger.debug("bounds: {}")
+    logger.debug(bounds)
+    logger.debug("cost function parameters: {}", cost_function_parameters)
+    logger.debug("====================================")
 
     if optimization_method == "global":
         opti, func_eval = differential_evolution(
@@ -160,7 +162,7 @@ def find_acquisition_function_maxima(gp, acquisition_function,
         func_eval = np.array(a["fun"])
         if func_eval.ndim == 0: func_eval = np.array([func_eval])
         if a["success"] is False:
-            print("local acquisition function optimization not successful, solution replaced with random point.")
+            logger.warning("local acquisition function optimization not successful, solution replaced with random point.")
             opti = np.array(x0)
             if opti.ndim != 2: opti = np.array([opti])
             func_eval = evaluate_acquisition_function(x0,
@@ -173,8 +175,8 @@ def find_acquisition_function_maxima(gp, acquisition_function,
     #print("     x: ", opti)
     #print("  f(x): ", func_eval)
     if func_eval.ndim != 1 or opti.ndim != 2:
-        print("f(x): ", func_eval)
-        print("x: ", opti)
+        logger.error("f(x): ", func_eval)
+        logger.error("x: ", opti)
         raise Exception(
             "The output of the acquisition function optimization dim (f) != 1 or dim(x) != 2. Please check your "
             "acquisition function. It should return a 1-d numpy array")
@@ -198,7 +200,7 @@ def differential_evolution(ObjectiveFunction,
     fun = partial(ObjectiveFunction, gp=gp, acquisition_function=acquisition_function, origin=origin,
                   cost_function=cost_function, cost_function_parameters=cost_function_parameters)
     res = devo(
-        fun, bounds, tol=tol, disp=True, maxiter=max_iter, popsize=popsize, polish=False
+        fun, bounds, tol=tol, maxiter=max_iter, popsize=popsize, polish=False
     )
     return [list(res["x"])], list([res["fun"]])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ fvgp >= 3.2.11
 hgdl >= 1.4.6
 plotly
 notebook
+loguru

--- a/scripts/cost_function.py
+++ b/scripts/cost_function.py
@@ -1,6 +1,7 @@
 from typing import Callable
 
 import numpy as np
+from loguru import logger
 from scipy.optimize import differential_evolution as devo
 
 
@@ -31,8 +32,8 @@ def _update_cost_function(costs,
                           parameters,
                           cost_func: Callable,
                           compute_cost_misfit_func: Callable):
-    print("Cost adjustment in progress...")
-    print("old cost parameters: ", parameters)
+    logger.debug("Cost adjustment in progress...")
+    logger.debug("old cost parameters: ", parameters)
     bounds = 0.0
     # print(bounds)
     # input()
@@ -66,12 +67,11 @@ def _update_cost_function(costs,
                bounds,
                args=(origins, points, c),
                tol=1e-6,
-               disp=True,
                maxiter=300,
                popsize=20,
                polish=False)
     arguments = {"offset": res["x"][0], "slope": res["x"][1]}
-    print("New cost parameters: ", arguments)
+    logger.debug("New cost parameters: ", arguments)
     return arguments
 
 

--- a/scripts/instrument_function.py
+++ b/scripts/instrument_function.py
@@ -20,6 +20,7 @@ import numpy as np
 #################################################
 ############test with synthetic function#########
 #################################################
+from loguru import logger
 
 
 def synthetic_function(data, instrument_dict):
@@ -44,7 +45,7 @@ def send_zipped_pickle(obj, socket, flags=0, protocol=-1):
     """pack and compress an object with pickle and zlib."""
     pobj = pickle.dumps(obj, protocol)
     zobj = zlib.compress(pobj)
-    print('zipped pickle is %i bytes' % len(zobj))
+    logger.debug('zipped pickle is %i bytes' % len(zobj))
     return socket.send(zobj, flags=flags)
 
 
@@ -61,12 +62,12 @@ def recv_zipped_pickle(socket, flags=0):
 
 def comm_via_zmq(data, instrument_dict):
     send_zipped_pickle(data, socket)
-    print("gpCAM has sent data of length: ", len(data))
-    # print(data)
-    print("=================================")
+    logger.debug("gpCAM has sent data of length: ", len(data))
+    logger.debug(data)
+    logger.debug("=================================")
     data = recv_zipped_pickle(socket)
-    print("gpCAM has received data of length: ", len(data))
-    # print(data)
+    logger.debug("gpCAM has received data of length: ", len(data))
+    logger.debug(data)
     # input()
     return data
 

--- a/scripts/kernel_function.py
+++ b/scripts/kernel_function.py
@@ -1,5 +1,6 @@
 import numpy as np
 from matplotlib import pyplot as plt
+from loguru import logger
 
 
 def kernel_l2_single_task(x1, x2, hyperparameters, obj):
@@ -102,8 +103,8 @@ def gamma(x, hps):
 def non_stat_kernel_2d(x1, x2, hps, obj):
     x1 = x1[:, :-1]
     x2 = x2[:, :-1]
-    print(x1)
-    print(x2)
+    logger.debug(x1)
+    logger.debug(x2)
     C = np.empty((len(x1), len(x2)))
     for i in range(len(x1)):
         for j in range(len(x2)):
@@ -295,7 +296,7 @@ def psd_kernel_test1(func, hps, obj):
     for i in range(100):
         x = np.random.rand(1000)
         K = func(x, x, hps, obj)
-        print("check if it is 0 or larger (allow for machine precision zero): ", np.min(np.real(np.linalg.eig(K)[0])))
+        logger.debug("check if it is 0 or larger (allow for machine precision zero): {}", np.min(np.real(np.linalg.eig(K)[0])))
 
 
 def psd_proof(N, kernel):

--- a/scripts/run_every_iteration.py
+++ b/scripts/run_every_iteration.py
@@ -1,30 +1,31 @@
 # FIXME: unused module?
 import numpy as np
+from loguru import logger
 
 
 def write_vtk_file(gp_optimizer_obj):
     # FIXME: unused function?
-    print("This will be printed in every iteration of gpCAM")
+    logger.debug("This will be printed in every iteration of gpCAM")
     plot_dim = [[0, 28], [0, 41]]
     resolution = [100, 100]
-    print("plotting dims:", plot_dim)
+    logger.debug("plotting dims: {}", plot_dim)
     l = [len(plot_dim[i]) for i in range(len(plot_dim))]
     plot_indices = [i for i, x in enumerate(l) if x == 2]
     slice_indices = [i for i, x in enumerate(l) if x == 1]
     file_name = "vid.csv." + str(len(gp_optimizer_obj.points)).zfill(5)
     file_name_p = "vid_p.csv." + str(len(gp_optimizer_obj.points)).zfill(5)
-    print("writing csv file", file_name)
+    logger.debug("writing csv file {}", file_name)
     xs = (plot_dim[plot_indices[0]][0], plot_dim[plot_indices[0]][1], resolution[0])
     ys = (plot_dim[plot_indices[1]][0], plot_dim[plot_indices[1]][1], resolution[1])
-    print(xs)
-    print(ys)
+    logger.debug(xs)
+    logger.debug(ys)
 
     x = np.linspace(*xs)
     y = np.linspace(*ys)
     mean = np.zeros((len(x) * len(y)))
     points = np.zeros((len(x) * len(y), 2))
-    print("plot indices:", plot_indices)
-    print("slice indices:", slice_indices)
+    logger.debug("plot indices:", plot_indices)
+    logger.debug("slice indices:", slice_indices)
     index = 0
     for i in range(len(x)):
         for j in range(len(y)):

--- a/tests/test_gpCAM.py
+++ b/tests/test_gpCAM.py
@@ -15,7 +15,7 @@ def ac_func1(x, obj):
     std_model = np.sqrt(r2)
     return -(r1 + 3.0 * std_model)
 
-def instrument(data):
+def instrument(data, instrument_dict=None):
     for entry in data:
         entry["value"] = np.sin(np.linalg.norm(entry["position"]))
     return data


### PR DESCRIPTION
See also PRs in fvGP and HGDL

This PR change all prints to logging calls. This allows a more library-like usage of gpCAM components, while also enabling configurability for logging levels. This means that in typical usage you will no longer see the many printed notes from gpCAM. However, you can re-enable those messages a few ways.

- When using the `.go` method, pass `info=True`
- enable printing the log explicitly with `loguru.logger.enable('gpCAM')`
- further, the log output can be redirected to file if desired (see loguru docs)
- if command-line usage of gpCAM is enabled, we would parse args like `-v` and `-vvv` to allow users to choose the printed verbosity level

https://github.com/lbl-camera/fvGP/pull/12
https://github.com/lbl-camera/HGDL/pull/14