### PR TITLE
Fix automatic use of HGDL when N>1 suggestions requested

### DIFF
--- a/gpcam/gp_optimizer.py
+++ b/gpcam/gp_optimizer.py
@@ -356,7 +356,7 @@ class GPOptimizer(GP):
             max_iter=20,
             tol=1e-6,
             x0=None,
-            dask_client=False):
+            dask_client=None):
 
         """
         Given that the acquisition device is at "position", the function ask()s for

--- a/gpcam/surrogate_model.py
+++ b/gpcam/surrogate_model.py
@@ -94,7 +94,7 @@ def find_acquisition_function_maxima(gp, acquisition_function,
                                      optimization_x0=None,
                                      cost_function=None,
                                      cost_function_parameters=None,
-                                     dask_client=False):
+                                     dask_client=None):
     bounds = np.array(optimization_bounds)
     opt_obj = None
     logger.debug("====================================")


### PR DESCRIPTION
The default parameter value for `dask_client` was `False`, causing checks of `dask_client is None` to fail. This updates the defaults to `None`.