### PR TITLE
Add exception for typo'd acquisition functions.

### DIFF
--- a/gpcam/surrogate_model.py
+++ b/gpcam/surrogate_model.py
@@ -90,6 +90,8 @@ def evaluate_gp_acquisition_function(x, acquisition_function, gp):
         res = gp.posterior_mean(x)["f(x)"]
         return -res
 
+    raise ValueError(f'The requested acquisition function "{acquisition_function}" does not exist.')
+
 
 ##########################################################################
 def find_acquisition_function_maxima(gp, acquisition_function,


### PR DESCRIPTION
In cases where the named acquisition function isn't matched, this will raise an error. The prior behavior was to return `None`.