### PR TITLE
Replace zmq with pyzmq

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pandas
 ophyd
 dask >= 2021.6.2
 distributed >= 2021.6.2
-zmq
+pyzmq
 fvgp == 3.3.7
 plotly
 notebook


### PR DESCRIPTION
`zmq` is just a place holder for `pyzmq` so it is better to use `pyzmq` directly: 
https://pypi.org/project/zmq/