### PR TITLE
Fix marketplace.json plugin source path ("." -> "./")

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "gpcam",
-      "source": ".",
+      "source": "./",
       "description": "Skills that guide an AI assistant through designing autonomous experiments with gpCAM — kernels, acquisition, prior mean, noise, cost, gp2Scale, and multi-task GPs.",
       "homepage": "https://gpcam.lbl.gov",
       "category": "scientific-computing",


### PR DESCRIPTION
The plugin `source` in `.claude-plugin/marketplace.json` is set to a bare `"."`. Claude Code's marketplace parser only recognizes relative paths starting with `./` or `../`, absolute paths, or the `owner/repo` shorthand, so a bare `.` is rejected.

`/plugin install gpcam@gpcam` then fails with:

> This plugin uses a source type your Claude Code version does not support. Update Claude Code and try again.

which is misleading — it reproduces on the latest Claude Code (2.1.162), and "updating" cannot fix it. Other working marketplaces use `"./"`.

**Fix:** `"source": "."` → `"source": "./"`. One character; resolves the plugin at the marketplace repo root and lets the install succeed.

Verified locally by patching the cached marketplace clone and re-running `/plugin install gpcam@gpcam`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)