### PR TITLE
CI: publish skills/ as a zip in GitHub releases

### DIFF
--- a/.github/workflows/gpCAM-CI.yml
+++ b/.github/workflows/gpCAM-CI.yml
@@ -69,6 +69,9 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true
 
+      - name: Package skills
+        run: zip -r dist/gpcam-skills.zip skills
+
       - name: Github Release
         uses: fnkr/github-action-ghr@v1
         env:

--- a/.github/workflows/gpCAM-CI.yml
+++ b/.github/workflows/gpCAM-CI.yml
@@ -75,6 +75,5 @@ jobs:
       - name: Github Release
         uses: fnkr/github-action-ghr@v1
         env:
-          GHR_COMPRESS: xz
           GHR_PATH: dist/
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a `Package skills` step to the deploy job that zips the `skills/` directory into `dist/` (`gpcam-skills.zip`), so the Claude skills get published as an asset on every tagged GitHub release. The step runs after the PyPI publish (so twine never sees the non-package zip) and before the release step uploads `dist/`.
- Drop `GHR_COMPRESS: xz` from the release step: it was re-compressing every asset, so releases shipped `gpcam-X.Y.Z.tar.gz.tar.xz` / `.whl.tar.xz` (and the skills zip would have become `gpcam-skills.zip.tar.xz`). Assets now upload as-is. This is a separate commit in case the xz wrapping was intentional.

## Test plan
- [x] Workflow YAML parses; deploy step order verified: build -> PyPI publish -> Package skills -> Github Release
- [ ] Verify `gpcam-skills.zip` appears on the next tagged release

🤖 Generated with [Claude Code](https://claude.com/claude-code)